### PR TITLE
[codex] Add wavefront path tracing budget adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,19 @@ The format is based on **[Keep a Changelog](https://keepachangelog.com/en/1.1.0/
 ## [Unreleased]
 
 - **Added**
-  - (placeholder)
+  - Added a dedicated wavefront path-tracing budget adapter with explicit
+    controls for bounce depth, SPP, queue capacity, optional light probes,
+    BVH cadence, denoise mode, temporal accumulation, and render scale.
 
 - **Changed**
-  - (placeholder)
+  - Ray-tracing-first docs now distinguish generic budget metadata from the
+    concrete wavefront-path controls used to preserve emissive/environment
+    correctness while degrading optional variance-reduction work first.
 
 - **Fixed**
-  - (placeholder)
+  - Wavefront budget normalization now validates independent control changes for
+    depth, probe mode, and render scale instead of forcing callers through a
+    single coarse ladder dimension.
 
 - **Security**
   - (placeholder)

--- a/README.md
+++ b/README.md
@@ -158,6 +158,69 @@ That lets modules preserve representation tiers and degrade cheaper cadence,
 history, and RT-fidelity controls before more expensive geometry or
 authoritative work.
 
+Wavefront path tracing now has a dedicated adapter surface when a caller needs
+concrete controls rather than generic metadata:
+
+```ts
+import {
+  createWavefrontPathTracingBudgetAdapter,
+} from "@plasius/gpu-performance";
+
+const wavefrontBudget = createWavefrontPathTracingBudgetAdapter({
+  id: "wavefront-path-tracing",
+  levels: [
+    {
+      id: "reduced",
+      estimatedCostMs: 1.4,
+      config: {
+        maxBounceDepth: 3,
+        samplesPerPixel: 1,
+        activeRayQueueCapacity: 1024,
+        explicitLightSamples: 0,
+        visibilityProbeMode: "disabled",
+        bvhUpdateCadence: 4,
+        denoiseMode: "off",
+        temporalAccumulation: false,
+        renderScale: 0.7,
+      },
+    },
+    {
+      id: "full",
+      estimatedCostMs: 3.9,
+      config: {
+        maxBounceDepth: 6,
+        samplesPerPixel: 4,
+        activeRayQueueCapacity: 4096,
+        explicitLightSamples: 2,
+        visibilityProbeMode: "mis-balanced",
+        bvhUpdateCadence: 1,
+        denoiseMode: "spatiotemporal",
+        temporalAccumulation: true,
+        renderScale: 1,
+      },
+    },
+  ],
+});
+
+console.log(wavefrontBudget.getControlSummary().degradeFirst);
+console.log(wavefrontBudget.getCurrentBudget().renderScale);
+```
+
+The dedicated wavefront adapter names the P0 controls directly:
+
+- `maxBounceDepth`
+- `samplesPerPixel`
+- `activeRayQueueCapacity`
+- `explicitLightSamples`
+- `visibilityProbeMode`
+- `bvhUpdateCadence`
+- `denoiseMode`
+- `temporalAccumulation`
+- `renderScale`
+
+Its control summary keeps the active-ray emissive/environment baseline protected
+while degrading optional variance-reduction work first.
+
 ## Worker-Job Governance
 
 For `@plasius/gpu-*` packages that schedule work through `@plasius/gpu-worker`,

--- a/docs/tdrs/tdr-0004-ray-tracing-first-quality-budget-contract.md
+++ b/docs/tdrs/tdr-0004-ray-tracing-first-quality-budget-contract.md
@@ -23,6 +23,18 @@ groups:
 - lighting sample budget
 - update cadence and temporal reuse
 
+The first wavefront-path slice now publishes an explicit control set for:
+
+- `maxBounceDepth`
+- `samplesPerPixel`
+- `activeRayQueueCapacity`
+- `explicitLightSamples`
+- `visibilityProbeMode`
+- `bvhUpdateCadence`
+- `denoiseMode`
+- `temporalAccumulation`
+- `renderScale`
+
 ## Representation Tiers
 
 The contract should also preserve representation-tier context for the work being
@@ -57,6 +69,9 @@ Unit tests should prove that:
 - near-field work outranks far-field work when pressure rises
 - leaf or proxy work degrades before high-fan-out RT or lighting roots
 - temporal reuse and update cadence can scale independently from geometry cost
+- wavefront path budgets preserve emissive/environment correctness while
+  degrading optional probe/light-sampling controls first
+- bounce depth, probe mode, and render scale remain independently adjustable
 
 ## Implementation Notes
 
@@ -65,3 +80,8 @@ with `representationBand`, `qualityDimensions`, and `importanceSignals`
 metadata. The governor now uses those inputs when ranking degrade candidates,
 and manifest graph normalization preserves representation tiers instead of
 dropping them.
+
+The wavefront path-tracing adapter adds a concrete named contract on top of
+that metadata so downstream packages can express P0 controls without inventing
+package-local enums or flattening optional probe work into the same knob as
+emissive/environment correctness.

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,13 @@ export {
   representationBands,
 } from "./budget.js";
 export {
+  createWavefrontPathTracingBudgetAdapter,
+  normalizeWavefrontPathTracingBudgetConfig,
+  wavefrontPathTracingBudgetControlKeys,
+  wavefrontPathTracingDenoiseModes,
+  wavefrontPathTracingVisibilityProbeModes,
+} from "./wavefront.js";
+export {
   createGpuPerformanceGovernor,
   createPerformanceGovernor,
   defaultDomainOrder,

--- a/src/types.ts
+++ b/src/types.ts
@@ -360,6 +360,76 @@ export interface WorkerJobBudgetConfig {
 }
 
 /**
+ * Denoising modes for wavefront-path preview quality control.
+ */
+export type WavefrontPathTracingDenoiseMode =
+  | "off"
+  | "spatial"
+  | "spatiotemporal";
+
+/**
+ * Probe/light-sampling modes for optional variance reduction.
+ */
+export type WavefrontPathTracingVisibilityProbeMode =
+  | "disabled"
+  | "mis-balanced"
+  | "exclusive-emissive";
+
+/**
+ * Explicit wavefront path-tracing budget controls.
+ */
+export interface WavefrontPathTracingBudgetConfig {
+  maxBounceDepth: number;
+  samplesPerPixel: number;
+  activeRayQueueCapacity: number;
+  explicitLightSamples: number;
+  visibilityProbeMode: WavefrontPathTracingVisibilityProbeMode;
+  bvhUpdateCadence: number;
+  denoiseMode: WavefrontPathTracingDenoiseMode;
+  temporalAccumulation: boolean;
+  renderScale: number;
+  preserveEmissiveEnvironmentBaseline?: boolean;
+  degradeOptionalFirst?: boolean;
+}
+
+/**
+ * Stable summary of the protected-vs-optional wavefront budget semantics.
+ */
+export interface WavefrontPathTracingBudgetControlSummary {
+  preservesEmissiveEnvironmentBaseline: boolean;
+  degradeOptionalFirst: boolean;
+  degradeFirst: readonly string[];
+  independentControls: readonly string[];
+}
+
+/**
+ * Creation options for a wavefront path-tracing budget adapter.
+ */
+export interface WavefrontPathTracingBudgetAdapterOptions {
+  id: string;
+  domain?: PerformanceDomain;
+  authority?: ModuleAuthority;
+  importance?: ModuleImportance;
+  representationBand?: RepresentationBand;
+  qualityDimensions?: PerformanceQualityDimensions;
+  importanceSignals?: Readonly<PerformanceImportanceSignals>;
+  levels: readonly ModuleQualityLevel<WavefrontPathTracingBudgetConfig>[];
+  initialLevel?: number | string;
+  onLevelChange?: (
+    event: QualityLadderChangeEvent<WavefrontPathTracingBudgetConfig>
+  ) => void;
+}
+
+/**
+ * Specialized adapter for wavefront path-tracing quality controls.
+ */
+export interface WavefrontPathTracingBudgetAdapter
+  extends QualityLadderAdapter<WavefrontPathTracingBudgetConfig> {
+  getCurrentBudget(): WavefrontPathTracingBudgetConfig;
+  getControlSummary(): WavefrontPathTracingBudgetControlSummary;
+}
+
+/**
  * Options for creating a worker-job budget adapter.
  */
 export interface WorkerJobBudgetAdapterOptions {

--- a/src/wavefront.ts
+++ b/src/wavefront.ts
@@ -1,0 +1,155 @@
+import { createQualityLadderAdapter } from "./ladder.js";
+import type {
+  WavefrontPathTracingBudgetAdapter,
+  WavefrontPathTracingBudgetAdapterOptions,
+  WavefrontPathTracingBudgetConfig,
+  WavefrontPathTracingBudgetControlSummary,
+  WavefrontPathTracingDenoiseMode,
+  WavefrontPathTracingVisibilityProbeMode,
+} from "./types.js";
+import {
+  assertEnumValue,
+  readNonNegativeNumber,
+  readPositiveNumber,
+} from "./validation.js";
+
+export const wavefrontPathTracingDenoiseModes = Object.freeze([
+  "off",
+  "spatial",
+  "spatiotemporal",
+]) satisfies readonly WavefrontPathTracingDenoiseMode[];
+
+export const wavefrontPathTracingVisibilityProbeModes = Object.freeze([
+  "disabled",
+  "mis-balanced",
+  "exclusive-emissive",
+]) satisfies readonly WavefrontPathTracingVisibilityProbeMode[];
+
+export const wavefrontPathTracingBudgetControlKeys = Object.freeze([
+  "maxBounceDepth",
+  "samplesPerPixel",
+  "activeRayQueueCapacity",
+  "explicitLightSamples",
+  "visibilityProbeMode",
+  "bvhUpdateCadence",
+  "denoiseMode",
+  "temporalAccumulation",
+  "renderScale",
+]) satisfies readonly string[];
+
+const wavefrontPathTracingControlSummary = Object.freeze({
+  preservesEmissiveEnvironmentBaseline: true,
+  degradeOptionalFirst: true,
+  degradeFirst: Object.freeze([
+    "explicitLightSamples",
+    "visibilityProbeMode",
+    "denoiseMode",
+    "temporalAccumulation",
+    "renderScale",
+  ]),
+  independentControls: wavefrontPathTracingBudgetControlKeys,
+}) satisfies WavefrontPathTracingBudgetControlSummary;
+
+function readPositiveInteger(name: string, value: unknown): number {
+  const parsed = readPositiveNumber(name, value);
+  return Math.max(1, Math.trunc(parsed ?? 1));
+}
+
+function readRenderScale(name: string, value: unknown): number {
+  const parsed = readPositiveNumber(name, value);
+  if ((parsed ?? 1) > 1) {
+    throw new Error(`${name} must be less than or equal to 1.`);
+  }
+  return parsed ?? 1;
+}
+
+export function normalizeWavefrontPathTracingBudgetConfig(
+  name: string,
+  value: unknown
+): WavefrontPathTracingBudgetConfig {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${name} must be a plain object.`);
+  }
+
+  const source = value as Record<string, unknown>;
+
+  return Object.freeze({
+    maxBounceDepth: readPositiveInteger(`${name}.maxBounceDepth`, source.maxBounceDepth),
+    samplesPerPixel: readPositiveInteger(`${name}.samplesPerPixel`, source.samplesPerPixel),
+    activeRayQueueCapacity: readPositiveInteger(
+      `${name}.activeRayQueueCapacity`,
+      source.activeRayQueueCapacity
+    ),
+    explicitLightSamples: Math.max(
+      0,
+      Math.trunc(
+        readNonNegativeNumber(
+          `${name}.explicitLightSamples`,
+          source.explicitLightSamples
+        ) ?? 0
+      )
+    ),
+    visibilityProbeMode: assertEnumValue(
+      `${name}.visibilityProbeMode`,
+      source.visibilityProbeMode,
+      wavefrontPathTracingVisibilityProbeModes
+    ),
+    bvhUpdateCadence: readPositiveInteger(
+      `${name}.bvhUpdateCadence`,
+      source.bvhUpdateCadence
+    ),
+    denoiseMode: assertEnumValue(
+      `${name}.denoiseMode`,
+      source.denoiseMode,
+      wavefrontPathTracingDenoiseModes
+    ),
+    temporalAccumulation: source.temporalAccumulation === true,
+    renderScale: readRenderScale(`${name}.renderScale`, source.renderScale),
+    preserveEmissiveEnvironmentBaseline:
+      source.preserveEmissiveEnvironmentBaseline !== false,
+    degradeOptionalFirst: source.degradeOptionalFirst !== false,
+  });
+}
+
+export function createWavefrontPathTracingBudgetAdapter(
+  options: WavefrontPathTracingBudgetAdapterOptions
+): WavefrontPathTracingBudgetAdapter {
+  const adapter = createQualityLadderAdapter<WavefrontPathTracingBudgetConfig>({
+    ...options,
+    domain: options.domain ?? "lighting",
+    authority: options.authority ?? "visual",
+    importance: options.importance ?? "critical",
+    representationBand: options.representationBand ?? "near",
+    qualityDimensions: options.qualityDimensions ?? {
+      rayTracing: 1,
+      lightingSamples: 1,
+      updateCadence: 1,
+      temporalReuse: 1,
+    },
+    importanceSignals: options.importanceSignals ?? {
+      visible: true,
+      playerRelevant: true,
+      shadowSignificance: "high",
+      reflectionSignificance: "high",
+    },
+    levels: options.levels.map((level, index) =>
+      Object.freeze({
+        ...level,
+        config: normalizeWavefrontPathTracingBudgetConfig(
+          `levels[${index}].config`,
+          level.config
+        ),
+      })
+    ),
+  });
+
+  return {
+    ...adapter,
+    getCurrentBudget() {
+      return adapter.getCurrentLevel().config;
+    },
+    getControlSummary() {
+      return wavefrontPathTracingControlSummary;
+    },
+  };
+}

--- a/tests/ray-tracing-budget-planning.test.ts
+++ b/tests/ray-tracing-budget-planning.test.ts
@@ -4,10 +4,15 @@ import {
   createDeviceProfile,
   createGpuPerformanceGovernor,
   createQualityLadderAdapter,
+  createWavefrontPathTracingBudgetAdapter,
   createWorkerJobBudgetAdaptersFromManifest,
   createWorkerJobBudgetManifestGraph,
+  normalizeWavefrontPathTracingBudgetConfig,
   rayTracingQualityDimensions,
   representationBands,
+  wavefrontPathTracingBudgetControlKeys,
+  wavefrontPathTracingDenoiseModes,
+  wavefrontPathTracingVisibilityProbeModes,
 } from "../src/index.js";
 
 function createPressureGovernor(modules: Parameters<typeof createGpuPerformanceGovernor>[0]["modules"]) {
@@ -210,6 +215,143 @@ describe("ray-tracing-first budget contract", () => {
     expect(visual.getSnapshot().currentLevel.id).toBe("reduced");
     expect(physics.getSnapshot().currentLevel.id).toBe("fixed");
   });
+
+  it("publishes explicit wavefront path-tracing budget controls for the P0 slice", () => {
+    const adapter = createWavefrontPathTracingBudgetAdapter({
+      id: "wavefront-path-tracing",
+      levels: [
+        {
+          id: "reduced",
+          estimatedCostMs: 1.4,
+          config: {
+            maxBounceDepth: 3,
+            samplesPerPixel: 1,
+            activeRayQueueCapacity: 1024,
+            explicitLightSamples: 0,
+            visibilityProbeMode: "disabled",
+            bvhUpdateCadence: 4,
+            denoiseMode: "off",
+            temporalAccumulation: false,
+            renderScale: 0.7,
+          },
+        },
+        {
+          id: "full",
+          estimatedCostMs: 3.9,
+          config: {
+            maxBounceDepth: 6,
+            samplesPerPixel: 4,
+            activeRayQueueCapacity: 4096,
+            explicitLightSamples: 2,
+            visibilityProbeMode: "mis-balanced",
+            bvhUpdateCadence: 1,
+            denoiseMode: "spatiotemporal",
+            temporalAccumulation: true,
+            renderScale: 1,
+          },
+        },
+      ],
+    });
+
+    expect(wavefrontPathTracingBudgetControlKeys).toEqual([
+      "maxBounceDepth",
+      "samplesPerPixel",
+      "activeRayQueueCapacity",
+      "explicitLightSamples",
+      "visibilityProbeMode",
+      "bvhUpdateCadence",
+      "denoiseMode",
+      "temporalAccumulation",
+      "renderScale",
+    ]);
+    expect(wavefrontPathTracingDenoiseModes).toEqual([
+      "off",
+      "spatial",
+      "spatiotemporal",
+    ]);
+    expect(wavefrontPathTracingVisibilityProbeModes).toEqual([
+      "disabled",
+      "mis-balanced",
+      "exclusive-emissive",
+    ]);
+    expect(adapter.getCurrentBudget()).toMatchObject({
+      maxBounceDepth: 6,
+      samplesPerPixel: 4,
+      activeRayQueueCapacity: 4096,
+      explicitLightSamples: 2,
+      visibilityProbeMode: "mis-balanced",
+      bvhUpdateCadence: 1,
+      denoiseMode: "spatiotemporal",
+      temporalAccumulation: true,
+      renderScale: 1,
+      preserveEmissiveEnvironmentBaseline: true,
+      degradeOptionalFirst: true,
+    });
+  });
+
+  it("protects the active-ray emissive/environment baseline while degrading optional variance reduction first", () => {
+    const adapter = createWavefrontPathTracingBudgetAdapter({
+      id: "wavefront-path-tracing",
+      levels: [
+        {
+          id: "reduced",
+          estimatedCostMs: 1.4,
+          config: {
+            maxBounceDepth: 6,
+            samplesPerPixel: 2,
+            activeRayQueueCapacity: 4096,
+            explicitLightSamples: 0,
+            visibilityProbeMode: "disabled",
+            bvhUpdateCadence: 2,
+            denoiseMode: "off",
+            temporalAccumulation: false,
+            renderScale: 0.85,
+          },
+        },
+        {
+          id: "full",
+          estimatedCostMs: 4.2,
+          config: {
+            maxBounceDepth: 6,
+            samplesPerPixel: 4,
+            activeRayQueueCapacity: 4096,
+            explicitLightSamples: 2,
+            visibilityProbeMode: "mis-balanced",
+            bvhUpdateCadence: 1,
+            denoiseMode: "spatiotemporal",
+            temporalAccumulation: true,
+            renderScale: 1,
+          },
+        },
+      ],
+    });
+
+    expect(adapter.getControlSummary()).toEqual({
+      preservesEmissiveEnvironmentBaseline: true,
+      degradeOptionalFirst: true,
+      degradeFirst: [
+        "explicitLightSamples",
+        "visibilityProbeMode",
+        "denoiseMode",
+        "temporalAccumulation",
+        "renderScale",
+      ],
+      independentControls: wavefrontPathTracingBudgetControlKeys,
+    });
+
+    const governor = createPressureGovernor([adapter]);
+    applyPressure(governor);
+
+    expect(adapter.getCurrentBudget()).toMatchObject({
+      maxBounceDepth: 6,
+      activeRayQueueCapacity: 4096,
+      explicitLightSamples: 0,
+      visibilityProbeMode: "disabled",
+      denoiseMode: "off",
+      temporalAccumulation: false,
+      renderScale: 0.85,
+    });
+  });
 });
 
 describe("ray-tracing-first governor unit planning", () => {
@@ -327,5 +469,53 @@ describe("ray-tracing-first governor unit planning", () => {
     expect(decision.adjustments[0]?.moduleId).toBe("near-rt-reflections");
     expect(rayTracing.getSnapshot().currentLevel.id).toBe("reduced");
     expect(geometry.getSnapshot().currentLevel.id).toBe("high");
+  });
+
+  it("normalizes wavefront path-tracing controls so depth, probes, and render scale vary independently", () => {
+    const conservative = normalizeWavefrontPathTracingBudgetConfig("budget", {
+      maxBounceDepth: 2,
+      samplesPerPixel: 1,
+      activeRayQueueCapacity: 512,
+      explicitLightSamples: 0,
+      visibilityProbeMode: "disabled",
+      bvhUpdateCadence: 4,
+      denoiseMode: "off",
+      temporalAccumulation: false,
+      renderScale: 0.7,
+    });
+    const probeHeavy = normalizeWavefrontPathTracingBudgetConfig("budget", {
+      maxBounceDepth: 2,
+      samplesPerPixel: 1,
+      activeRayQueueCapacity: 512,
+      explicitLightSamples: 2,
+      visibilityProbeMode: "exclusive-emissive",
+      bvhUpdateCadence: 4,
+      denoiseMode: "off",
+      temporalAccumulation: false,
+      renderScale: 0.7,
+    });
+    const fullScale = normalizeWavefrontPathTracingBudgetConfig("budget", {
+      maxBounceDepth: 5,
+      samplesPerPixel: 3,
+      activeRayQueueCapacity: 2048,
+      explicitLightSamples: 2,
+      visibilityProbeMode: "mis-balanced",
+      bvhUpdateCadence: 1,
+      denoiseMode: "spatiotemporal",
+      temporalAccumulation: true,
+      renderScale: 1,
+    });
+
+    expect(conservative.maxBounceDepth).toBe(2);
+    expect(conservative.visibilityProbeMode).toBe("disabled");
+    expect(conservative.renderScale).toBe(0.7);
+
+    expect(probeHeavy.maxBounceDepth).toBe(2);
+    expect(probeHeavy.visibilityProbeMode).toBe("exclusive-emissive");
+    expect(probeHeavy.renderScale).toBe(0.7);
+
+    expect(fullScale.maxBounceDepth).toBe(5);
+    expect(fullScale.visibilityProbeMode).toBe("mis-balanced");
+    expect(fullScale.renderScale).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- add a dedicated wavefront path-tracing budget adapter with explicit controls for depth, SPP, queue capacity, optional light probes, BVH cadence, denoise mode, temporal accumulation, and render scale
- add tests proving baseline-preserving degrade order plus independent control of depth, probe mode, and render scale
- document the concrete wavefront budget contract in the README, changelog, and TDR

## Why
This closes `gpu-performance#15` under `plasius-ltd-site#1040` by turning the generic ray-tracing-first metadata into a concrete P0 wavefront quality-control surface.

## Impact
Consumers no longer need package-local enums or ad hoc config shapes to describe wavefront path-tracing budgets, and the governor can preserve emissive/environment correctness while degrading optional variance-reduction work first.

## Validation
- `npx vitest run tests/ray-tracing-budget-planning.test.ts`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run test:coverage`
- `npm run pack:check`
- `npm pack --dry-run --cache /private/tmp/npm-cache-hw2-gpu-performance-ws`
