### PR TITLE
[codex] Restore protected-main release path

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -22,6 +22,7 @@ permissions:
   contents: write
   id-token: write
   attestations: write
+  pull-requests: write
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -41,7 +42,7 @@ jobs:
           node-version-file: ".nvmrc"
           cache: "npm"
 
-      - name: Bump version & decide publish flags
+      - name: Prepare release metadata
         id: pkg
         env:
           BUMP: ${{ inputs.bump }}
@@ -51,43 +52,85 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          BUMP_CMD=""
-          case "${BUMP:-patch}" in
-            major|minor|patch)
-              if [ -n "${PREID:-}" ]; then
-                case "${BUMP}" in
-                  major) BUMP_CMD="npm version premajor --preid ${PREID} -m 'chore: release v%s [skip ci]'" ;;
-                  minor) BUMP_CMD="npm version preminor --preid ${PREID} -m 'chore: release v%s [skip ci]'" ;;
-                  patch) BUMP_CMD="npm version prepatch --preid ${PREID} -m 'chore: release v%s [skip ci]'" ;;
-                esac
-              else
-                BUMP_CMD="npm version ${BUMP} -m 'chore: release v%s [skip ci]'"
-              fi
-              ;;
-            none)
-              BUMP_CMD="echo"
-              ;;
-            *)
-              echo "Unknown bump type: ${BUMP}" >&2
-              exit 1
-              ;;
-          esac
+          CURRENT_VER=$(node -p "require('./package.json').version")
+          NAME=$(node -p "require('./package.json').name")
 
           if [ "${BUMP}" = "none" ]; then
             CURRENT_VER=$(node -p "require('./package.json').version")
             NEW_VER="v${CURRENT_VER}"
           else
-            NEW_VER=$(sh -lc "$BUMP_CMD")
+            case "${BUMP:-patch}" in
+              major|minor|patch) ;;
+              *)
+                echo "Unknown bump type: ${BUMP}" >&2
+                exit 1
+                ;;
+            esac
+
+            REGISTRY_VER=$(npm view "$NAME" version 2>/dev/null || true)
+            TAG_VER=$(
+              git ls-remote --tags origin "refs/tags/v*" |
+                awk '{ print $2 }' |
+                sed -E 's#refs/tags/v##; s#\^\{\}##' |
+                grep -E '^[0-9]+\.[0-9]+\.[0-9]+($|-)' |
+                sort -V |
+                tail -n 1 || true
+            )
+            TARGET_VER=$(node -e '
+          const [localVersion, registryVersion, tagVersion, bump, preid] = process.argv.slice(1);
+          const clean = (value) => String(value || "").replace(/^v/, "").trim();
+          const parse = (value) => {
+            const [core] = clean(value).split("-");
+            const parts = core.split(".").map((part) => Number(part));
+            if (parts.length !== 3 || parts.some((part) => !Number.isInteger(part) || part < 0)) {
+              throw new Error(`Invalid semver value: ${value}`);
+            }
+            return parts;
+          };
+          const compare = (left, right) => {
+            for (let index = 0; index < 3; index += 1) {
+              const diff = left[index] - right[index];
+              if (diff !== 0) return diff;
+            }
+            return 0;
+          };
+
+          const local = parse(localVersion);
+          const registry = registryVersion ? parse(registryVersion) : local;
+          const tag = tagVersion ? parse(tagVersion) : local;
+          let base = local;
+          if (compare(registry, base) > 0) base = registry;
+          if (compare(tag, base) > 0) base = tag;
+          let next;
+          switch (bump) {
+            case "major":
+              next = [base[0] + 1, 0, 0];
+              break;
+            case "minor":
+              next = [base[0], base[1] + 1, 0];
+              break;
+            case "patch":
+              next = [base[0], base[1], base[2] + 1];
+              break;
+            default:
+              throw new Error(`Unknown bump type: ${bump}`);
+          }
+
+          let version = next.join(".");
+          if (preid) {
+            version = `${version}-${preid}.0`;
+          }
+          process.stdout.write(version);
+          ' "$CURRENT_VER" "$REGISTRY_VER" "$TAG_VER" "$BUMP" "${PREID:-}")
+            NEW_VER=$(npm version "$TARGET_VER" --no-git-tag-version --allow-same-version)
           fi
 
           echo "New version: $NEW_VER"
-          git push --follow-tags
 
           VER_NO_V=${NEW_VER#v}
           echo "tag=$NEW_VER" >> "$GITHUB_OUTPUT"
           echo "version=$VER_NO_V" >> "$GITHUB_OUTPUT"
 
-          NAME=$(node -p "require('./package.json').name")
           echo "name=$NAME" >> "$GITHUB_OUTPUT"
           if npm view "$NAME" version >/dev/null 2>&1; then
             echo "flags=" >> "$GITHUB_OUTPUT"
@@ -145,9 +188,6 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
           FILE="CHANGELOG.md"
           if [ ! -f "$FILE" ]; then
             echo "No CHANGELOG.md found; skipping changelog update."
@@ -215,8 +255,47 @@ jobs:
           fi
 
           git add "$FILE"
-          git commit -m "docs(changelog): release v${VERSION}"
-          git push
+
+      - name: Commit release metadata and tag
+        env:
+          TAG: ${{ steps.pkg.outputs.tag }}
+          VERSION: ${{ steps.pkg.outputs.version }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch --tags origin
+          RELEASE_BRANCH="automation/release-${TAG#v}-${GITHUB_RUN_ID}"
+
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "Tag ${TAG} already exists. Immutable releases must use a new version."
+            exit 1
+          fi
+
+          git add package.json package-lock.json CHANGELOG.md
+          METADATA_CHANGED=0
+          if git diff --cached --quiet; then
+            echo "No release metadata changes to commit for ${TAG}; tagging current HEAD."
+          else
+            git commit -m "chore: release ${TAG} [skip ci]"
+            METADATA_CHANGED=1
+          fi
+
+          git tag "${TAG}"
+          if [ "$METADATA_CHANGED" = "1" ]; then
+            git push origin "HEAD:${RELEASE_BRANCH}" "${TAG}"
+            if ! gh pr create \
+              --base "${GITHUB_REF_NAME:-main}" \
+              --head "${RELEASE_BRANCH}" \
+              --title "docs(changelog): release ${TAG}" \
+              --body "Generated by the CD workflow for ${TAG}. The package publish uses the tagged release metadata commit; this PR persists package.json, package-lock.json, and CHANGELOG.md on the protected main branch."; then
+              echo "::warning::Unable to create release metadata PR from GitHub Actions. Branch ${RELEASE_BRANCH} and tag ${TAG} were pushed; publication will continue."
+            fi
+          else
+            git push origin "${TAG}"
+          fi
 
       - name: Create GitHub Release draft (immutable-safe)
         env:


### PR DESCRIPTION
## Summary
- replace the direct `main` release push in `cd.yml` with protected-branch-safe release metadata preparation
- create and push the release tag plus a dedicated `automation/release-*` metadata branch instead of pushing version/changelog commits straight to `main`
- grant the workflow PR creation permission and wire `gh pr create` through `GITHUB_TOKEN`/`GH_TOKEN` so release metadata can reach `main` through an approved PR path

## Root cause
The failing release run for `gpu-performance#15` died in `Bump version & decide publish flags` because the workflow ran `npm version ...` on `main` and immediately did `git push --follow-tags`. Branch protection rejects direct pushes to `main`, so the job never reached publish.

## Impact
This unblocks `gpu-performance#19`, which in turn is the remaining blocker for `plasius-ltd-site#1040`. The package release can now publish from the release tag while persisting `package.json`, `package-lock.json`, and `CHANGELOG.md` back to `main` through a normal PR.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/cd.yml"); puts "YAML_OK"'`
- `npm ci --no-fund --no-audit`
- `npm run lint`
- `npm run typecheck`
- `npm run test:coverage`
- `npm run build`
- `npm run pack:check`
- `npm pack --dry-run --cache /private/tmp/npm-cache-hw2-gpu-performance-release-fix`
