### PR TITLE
docs(changelog): release v0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ The format is based on **[Keep a Changelog](https://keepachangelog.com/en/1.1.0/
 ## [Unreleased]
 
 - **Added**
+  - (placeholder)
+
+- **Changed**
+  - (placeholder)
+
+- **Fixed**
+  - (placeholder)
+
+- **Security**
+  - (placeholder)
+
+## [0.1.9] - 2026-06-16
+
+- **Added**
   - Added a dedicated wavefront path-tracing budget adapter with explicit
     controls for bounce depth, SPP, queue capacity, optional light probes,
     BVH cadence, denoise mode, temporal accumulation, and render scale.
@@ -201,3 +215,4 @@ The format is based on **[Keep a Changelog](https://keepachangelog.com/en/1.1.0/
 [0.1.4]: https://github.com/Plasius-LTD/gpu-performance/releases/tag/v0.1.4
 [0.1.5]: https://github.com/Plasius-LTD/gpu-performance/releases/tag/v0.1.5
 [0.1.6]: https://github.com/Plasius-LTD/gpu-performance/releases/tag/v0.1.6
+[0.1.9]: https://github.com/Plasius-LTD/gpu-performance/releases/tag/v0.1.9

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@plasius/gpu-performance",
-  "version": "0.1.6",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@plasius/gpu-performance",
-      "version": "0.1.6",
+      "version": "0.1.9",
       "funding": [
         {
           "type": "patreon",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plasius/gpu-performance",
-  "version": "0.1.6",
+  "version": "0.1.9",
   "description": "Device-negotiated GPU performance governor and quality ladder coordination for Plasius rendering stacks.",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
Generated from successful cd.yml run 27635070873 to persist package.json, package-lock.json, and CHANGELOG.md for the published v0.1.9 release on protected main.