### PR TITLE
chore: prepare release v0.1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,20 @@ The format is based on **[Keep a Changelog](https://keepachangelog.com/en/1.1.0/
 - **Security**
   - (placeholder)
 
+## [0.1.10] - 2026-06-22
+
+- **Added**
+  - (placeholder)
+
+- **Changed**
+  - (placeholder)
+
+- **Fixed**
+  - (placeholder)
+
+- **Security**
+  - (placeholder)
+
 ## [0.1.9] - 2026-06-16
 
 - **Added**
@@ -216,3 +230,4 @@ The format is based on **[Keep a Changelog](https://keepachangelog.com/en/1.1.0/
 [0.1.5]: https://github.com/Plasius-LTD/gpu-performance/releases/tag/v0.1.5
 [0.1.6]: https://github.com/Plasius-LTD/gpu-performance/releases/tag/v0.1.6
 [0.1.9]: https://github.com/Plasius-LTD/gpu-performance/releases/tag/v0.1.9
+[0.1.10]: https://github.com/Plasius-LTD/gpu-performance/releases/tag/v0.1.10

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@plasius/gpu-performance",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@plasius/gpu-performance",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "funding": [
         {
           "type": "patreon",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plasius/gpu-performance",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Device-negotiated GPU performance governor and quality ladder coordination for Plasius rendering stacks.",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
## Summary
- prepare `v0.1.10` for publication from protected `main`
- update package metadata to `0.1.10`
- move the current `Unreleased` notes into `0.1.10`

The CD workflow will continue only after this release metadata is present on `main`.