### PR TITLE
ci: use GitHub App token for release prepare

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -89,7 +89,6 @@ jobs:
         with:
           client-id: ${{ inputs.release_prep_app_client_id }}
           private-key: ${{ secrets.RELEASE_PREP_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
           permission-contents: write
           permission-pull-requests: write
 


### PR DESCRIPTION
## Summary
- switch release metadata preparation from the temporary PAT path to a GitHub App installation token
- keep the release-prep PR flow so changelog and version updates still land on `main` before publish
- remove the `RELEASE_PREP_TOKEN` dependency from `release-prepare.yml`

## Validation
- workflow YAML parsed after update
- release workflow caller remains unchanged and still uses local `release-prepare.yml`