### PR TITLE
Harden npm OIDC release admission

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -49,12 +49,90 @@ jobs:
           ref: ${{ needs.prepare_release.outputs.commit_sha }}
           fetch-depth: 0
 
+      - name: Enforce exact-main successful CI
+        env:
+          EXPECTED_SHA: ${{ needs.prepare_release.outputs.commit_sha }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          if ! printf '%s' "${EXPECTED_SHA}" | grep -Eq '^[0-9a-f]{40}$'; then
+            echo "Release preparation did not return a full commit SHA." >&2
+            exit 1
+          fi
+
+          git fetch origin main --no-tags
+          REMOTE_MAIN="$(git rev-parse refs/remotes/origin/main)"
+          if [ "${REMOTE_MAIN}" != "${EXPECTED_SHA}" ]; then
+            echo "main moved from prepared commit ${EXPECTED_SHA} to ${REMOTE_MAIN}; refusing publication." >&2
+            exit 1
+          fi
+
+          DEADLINE=$((SECONDS + 1800))
+          MATCHES=0
+          while [ "${SECONDS}" -lt "${DEADLINE}" ]; do
+            RUNS="$(
+              gh api -X GET \
+                "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs" \
+                -f branch=main \
+                -f event=push \
+                -f head_sha="${EXPECTED_SHA}" \
+                -f status=success \
+                -f per_page=100
+            )"
+            MATCHES="$(
+              jq \
+                --arg sha "${EXPECTED_SHA}" \
+                '[.workflow_runs[] | select(
+                  .head_sha == $sha and
+                  .head_branch == "main" and
+                  .event == "push" and
+                  .status == "completed" and
+                  .conclusion == "success"
+                )] | length' \
+                <<<"${RUNS}"
+            )"
+            if [ "${MATCHES}" -gt 0 ]; then
+              echo "Exact-SHA CI succeeded for ${EXPECTED_SHA}."
+              break
+            fi
+            sleep 15
+          done
+
+          if [ "${MATCHES}" -le 0 ]; then
+            echo "No successful main push CI completed for ${EXPECTED_SHA} within 1800 seconds." >&2
+            exit 1
+          fi
+
       - name: Use Node.js 24
         uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
           registry-url: "https://registry.npmjs.org"
           cache: npm
+
+      - name: Verify release runtime
+        run: |
+          set -euo pipefail
+
+          ACTUAL_NODE="$(node --version | sed 's/^v//')"
+          if [ "${ACTUAL_NODE%%.*}" != "24" ]; then
+            echo "Expected Node.js 24, found ${ACTUAL_NODE}." >&2
+            exit 1
+          fi
+
+          ACTUAL_NPM="$(npm --version)"
+          node - "${ACTUAL_NPM}" <<'NODE'
+          const actual = process.argv[2].split(".").map(Number);
+          const minimum = "11.5.1".split(".").map(Number);
+          for (let index = 0; index < 3; index += 1) {
+            if (actual[index] > minimum[index]) process.exit(0);
+            if (actual[index] < minimum[index]) process.exit(1);
+          }
+          process.exit(0);
+          NODE
+
+          echo "Using Node.js ${ACTUAL_NODE} and npm ${ACTUAL_NPM}."
 
       - name: Use prepared release metadata
         id: release
@@ -230,17 +308,11 @@ jobs:
       - name: Publish package
         if: steps.release.outputs.should_publish_npm == 'true'
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           FLAGS: ${{ steps.release.outputs.flags }}
           PACKAGE_NAME: ${{ steps.release.outputs.package_name }}
           PACKAGE_VERSION: ${{ steps.release.outputs.release_version }}
         run: |
           set -euo pipefail
-          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
-            echo "NPM_TOKEN is required" >&2
-            exit 1
-          fi
-
           if npm view "${PACKAGE_NAME}@${PACKAGE_VERSION}" version --registry https://registry.npmjs.org >/dev/null 2>&1; then
             echo "${PACKAGE_NAME}@${PACKAGE_VERSION} already exists on npm; skipping duplicate publish."
             exit 0

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,6 +3,14 @@ name: CD (Publish to npm)
 on:
   workflow_dispatch:
     inputs:
+      phase:
+        description: "Release phase. Prepare creates the release commit; publish is dispatched automatically for that exact commit."
+        required: true
+        type: choice
+        default: prepare
+        options:
+          - prepare
+          - publish
       bump:
         description: "Version bump type"
         required: true
@@ -17,39 +25,52 @@ on:
         description: "Pre-release id (e.g. beta, rc). Leave blank for stable"
         required: false
         type: string
+      expected_commit_sha:
+        description: "Internal fail-closed binding for the publish phase"
+        required: false
+        type: string
+      release_tag:
+        description: "Internal fail-closed release tag for the publish phase"
+        required: false
+        type: string
 
 permissions:
-  actions: read
-  attestations: write
-  contents: write
-  id-token: write
-  pull-requests: write
+  contents: read
 
 concurrency:
-  group: npm-cd-${{ github.repository }}
+  group: npm-cd-${{ github.repository }}-${{ inputs.phase == 'publish' && format('publish-{0}', inputs.expected_commit_sha) || 'prepare' }}
   cancel-in-progress: false
 
 jobs:
   prepare_release:
+    if: inputs.phase == 'prepare'
+    permissions:
+      contents: read
     uses: ./.github/workflows/release-prepare.yml
     with:
       bump: ${{ inputs.bump }}
       preid: ${{ inputs.preid }}
       release_prep_app_client_id: ${{ vars.RELEASE_PREP_APP_CLIENT_ID }}
-    secrets: inherit
+    secrets:
+      RELEASE_PREP_APP_PRIVATE_KEY: ${{ secrets.RELEASE_PREP_APP_PRIVATE_KEY }}
 
-  publish:
+  queue_publish:
+    if: inputs.phase == 'prepare'
     needs: prepare_release
     runs-on: ubuntu-latest
     environment: production
+    permissions:
+      actions: write
+      contents: read
     steps:
       - name: Checkout prepared release commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.prepare_release.outputs.commit_sha }}
           fetch-depth: 0
+          persist-credentials: false
 
-      - name: Enforce exact-main successful CI
+      - name: Enforce exact-main successful CI before publication dispatch
         env:
           EXPECTED_SHA: ${{ needs.prepare_release.outputs.commit_sha }}
           GH_TOKEN: ${{ github.token }}
@@ -61,15 +82,7 @@ jobs:
             exit 1
           fi
 
-          git fetch origin main --no-tags
-          REMOTE_MAIN="$(git rev-parse refs/remotes/origin/main)"
-          if [ "${REMOTE_MAIN}" != "${EXPECTED_SHA}" ]; then
-            echo "main moved from prepared commit ${EXPECTED_SHA} to ${REMOTE_MAIN}; refusing publication." >&2
-            exit 1
-          fi
-
           DEADLINE=$((SECONDS + 1800))
-          MATCHES=0
           while [ "${SECONDS}" -lt "${DEADLINE}" ]; do
             RUNS="$(
               gh api -X GET \
@@ -92,32 +105,103 @@ jobs:
                 )] | length' \
                 <<<"${RUNS}"
             )"
+
             if [ "${MATCHES}" -gt 0 ]; then
               echo "Exact-SHA CI succeeded for ${EXPECTED_SHA}."
               break
             fi
+
             sleep 15
           done
 
-          if [ "${MATCHES}" -le 0 ]; then
+          if [ "${MATCHES:-0}" -le 0 ]; then
             echo "No successful main push CI completed for ${EXPECTED_SHA} within 1800 seconds." >&2
             exit 1
           fi
 
-      - name: Use Node.js 24
-        uses: actions/setup-node@v4
+      - name: Dispatch exact-main publish run
+        env:
+          EXPECTED_SHA: ${{ needs.prepare_release.outputs.commit_sha }}
+          RELEASE_TAG: ${{ needs.prepare_release.outputs.tag }}
+          PREID: ${{ needs.prepare_release.outputs.effective_preid }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          git fetch origin main --no-tags
+          REMOTE_MAIN="$(git rev-parse refs/remotes/origin/main)"
+          if [ "${REMOTE_MAIN}" != "${EXPECTED_SHA}" ]; then
+            echo "main moved from prepared commit ${EXPECTED_SHA} to ${REMOTE_MAIN}; refusing to dispatch publication." >&2
+            exit 1
+          fi
+
+          jq -n \
+            --arg sha "${EXPECTED_SHA}" \
+            --arg tag "${RELEASE_TAG}" \
+            --arg preid "${PREID}" \
+            '{
+              "ref": "main",
+              "inputs": {
+                "phase": "publish",
+                "bump": "none",
+                "preid": $preid,
+                "expected_commit_sha": $sha,
+                "release_tag": $tag
+              }
+            }' |
+            gh api -X POST \
+              "repos/${GITHUB_REPOSITORY}/actions/workflows/cd.yml/dispatches" \
+              --input -
+
+          echo "Queued tokenless publication of ${RELEASE_TAG} from ${EXPECTED_SHA}."
+
+  validate_and_pack:
+    if: inputs.phase == 'publish'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      package_name: ${{ steps.release.outputs.package_name }}
+      release_version: ${{ steps.release.outputs.release_version }}
+      release_tag: ${{ steps.release.outputs.release_tag }}
+      effective_preid: ${{ steps.release.outputs.effective_preid }}
+      tarball_name: ${{ steps.bundle.outputs.tarball_name }}
+      tarball_sha256: ${{ steps.bundle.outputs.tarball_sha256 }}
+      tarball_artifact_id: ${{ steps.upload_package.outputs.artifact-id }}
+      tarball_artifact_digest: ${{ steps.upload_package.outputs.artifact-digest }}
+      sbom_sha256: ${{ steps.bundle.outputs.sbom_sha256 }}
+      sbom_artifact_id: ${{ steps.upload_sbom.outputs.artifact-id }}
+      sbom_artifact_digest: ${{ steps.upload_sbom.outputs.artifact-digest }}
+    steps:
+      - name: Checkout exact workflow commit
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Use Node.js 24.18.0
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
-          registry-url: "https://registry.npmjs.org"
-          cache: npm
+          package-manager-cache: false
+
+      - name: Install pinned npm release client
+        run: npm install --global npm@11.6.2 --ignore-scripts --registry https://registry.npmjs.org
 
       - name: Verify release runtime
         run: |
           set -euo pipefail
 
+          EXPECTED_NODE="$(tr -d '[:space:]' < .nvmrc)"
           ACTUAL_NODE="$(node --version | sed 's/^v//')"
           if [ "${ACTUAL_NODE%%.*}" != "24" ]; then
             echo "Expected Node.js 24, found ${ACTUAL_NODE}." >&2
+            exit 1
+          fi
+          if [ "${EXPECTED_NODE}" != "24.18.0" ] || [ "${ACTUAL_NODE}" != "${EXPECTED_NODE}" ]; then
+            echo "Expected Node.js 24.18.0, found ${ACTUAL_NODE} with .nvmrc=${EXPECTED_NODE}." >&2
             exit 1
           fi
 
@@ -134,39 +218,132 @@ jobs:
 
           echo "Using Node.js ${ACTUAL_NODE} and npm ${ACTUAL_NPM}."
 
-      - name: Use prepared release metadata
-        id: release
+      - name: Enforce exact-main release identity
+        env:
+          EXPECTED_SHA: ${{ inputs.expected_commit_sha }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
-          PUBLISHED="${{ needs.prepare_release.outputs.published }}"
+          if ! printf '%s' "${EXPECTED_SHA}" | grep -Eq '^[0-9a-f]{40}$'; then
+            echo "Publish requires a full expected_commit_sha." >&2
+            exit 1
+          fi
+          if [ -z "${RELEASE_TAG}" ]; then
+            echo "Publish requires release_tag." >&2
+            exit 1
+          fi
+          if [ '${{ github.ref }}' != "refs/heads/main" ]; then
+            echo "Publication must be dispatched from refs/heads/main." >&2
+            exit 1
+          fi
+          if [ '${{ github.sha }}' != "${EXPECTED_SHA}" ]; then
+            echo "Workflow SHA ${{ github.sha }} does not match prepared SHA ${EXPECTED_SHA}." >&2
+            exit 1
+          fi
+
+          git fetch origin main --no-tags
+          REMOTE_MAIN="$(git rev-parse refs/remotes/origin/main)"
+          if [ "${REMOTE_MAIN}" != "${EXPECTED_SHA}" ]; then
+            echo "Remote main ${REMOTE_MAIN} does not match prepared SHA ${EXPECTED_SHA}." >&2
+            exit 1
+          fi
+          git merge-base --is-ancestor "${EXPECTED_SHA}" refs/remotes/origin/main
+
+          RUNS="$(
+            gh api -X GET \
+              "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs" \
+              -f branch=main \
+              -f event=push \
+              -f head_sha="${EXPECTED_SHA}" \
+              -f status=success \
+              -f per_page=100
+          )"
+          MATCHES="$(
+            jq \
+              --arg sha "${EXPECTED_SHA}" \
+              '[.workflow_runs[] | select(
+                .head_sha == $sha and
+                .head_branch == "main" and
+                .event == "push" and
+                .status == "completed" and
+                .conclusion == "success"
+              )] | length' \
+              <<<"${RUNS}"
+          )"
+          if [ "${MATCHES}" -le 0 ]; then
+            echo "No successful exact-SHA main push CI exists for ${EXPECTED_SHA}." >&2
+            exit 1
+          fi
+
+      - name: Derive release metadata
+        id: release
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          PREID: ${{ inputs.preid }}
+        run: |
+          set -euo pipefail
+
+          PACKAGE_NAME="$(node -p "require('./package.json').name || ''")"
+          PACKAGE_VERSION="$(node -p "require('./package.json').version || ''")"
+          EXPECTED_TAG="v${PACKAGE_VERSION}"
+          if [ -z "${PACKAGE_NAME}" ] || [ -z "${PACKAGE_VERSION}" ]; then
+            echo "package.json must define name and version." >&2
+            exit 1
+          fi
+          if [ "${RELEASE_TAG}" != "${EXPECTED_TAG}" ]; then
+            echo "Release tag ${RELEASE_TAG} does not match package version ${PACKAGE_VERSION}." >&2
+            exit 1
+          fi
+          if [ -n "${PREID}" ] && ! printf '%s' "${PREID}" | grep -Eq '^[0-9A-Za-z][0-9A-Za-z.-]*$'; then
+            echo "Invalid pre-release id: ${PREID}" >&2
+            exit 1
+          fi
+
+          DERIVED_PREID=$(PACKAGE_VERSION="${PACKAGE_VERSION}" node -e '
+          const version = process.env.PACKAGE_VERSION || "";
+          const match = version.match(/^[0-9]+\.[0-9]+\.[0-9]+(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/);
+          if (!match) {
+            console.error(`Cannot derive pre-release identity from invalid version ${version}.`);
+            process.exit(1);
+          }
+          const identifiers = match[1] ? match[1].split(".") : [];
+          if (identifiers.length > 1 && /^[0-9]+$/.test(identifiers.at(-1))) {
+            identifiers.pop();
+          }
+          process.stdout.write(identifiers.join("."));
+          ')
+          if [ "${PREID}" != "${DERIVED_PREID}" ]; then
+            echo "Supplied pre-release identity ${PREID:-<stable>} does not match the pre-release identity derived from ${PACKAGE_VERSION} (${DERIVED_PREID:-<stable>})." >&2
+            exit 1
+          fi
+
           SHOULD_PUBLISH_NPM="true"
-          SKIP_REASON=""
-          if [ "${PUBLISHED}" = "true" ]; then
+          if npm view "${PACKAGE_NAME}@${PACKAGE_VERSION}" version --registry https://registry.npmjs.org >/dev/null 2>&1; then
             SHOULD_PUBLISH_NPM="false"
-            SKIP_REASON="Package version ${{ needs.prepare_release.outputs.version }} is already published; nothing to release."
           fi
 
           {
-            echo "package_name=${{ needs.prepare_release.outputs.name }}"
-            echo "release_version=${{ needs.prepare_release.outputs.version }}"
-            echo "release_tag=${{ needs.prepare_release.outputs.tag }}"
-            echo "flags=${{ needs.prepare_release.outputs.flags }}"
+            echo "package_name=${PACKAGE_NAME}"
+            echo "release_version=${PACKAGE_VERSION}"
+            echo "release_tag=${RELEASE_TAG}"
             echo "should_publish_npm=${SHOULD_PUBLISH_NPM}"
-            echo "should_finalize_release=true"
-            echo "skip_reason=${SKIP_REASON}"
-          } >> "$GITHUB_OUTPUT"
+            echo "derived_preid=${DERIVED_PREID}"
+            echo "effective_preid=${DERIVED_PREID}"
+          } >> "${GITHUB_OUTPUT}"
 
-      - name: Skip when package version is already published
-        if: steps.release.outputs.should_publish_npm != 'true'
-        run: echo "${{ steps.release.outputs.skip_reason }}"
+      - name: Verify private artifact policy
+        run: |
+          set -euo pipefail
+          if node -e "const scripts = require('./package.json').scripts || {}; process.exit(scripts['privacy:check'] ? 0 : 1)"; then
+            npm run privacy:check
+          fi
 
       - name: Install dependencies
-        if: steps.release.outputs.should_finalize_release == 'true'
         run: npm ci
 
       - name: Run validation
-        if: steps.release.outputs.should_finalize_release == 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -186,9 +363,64 @@ jobs:
           fi
           if has_script pack:check; then npm run pack:check; fi
 
+      - name: Generate SBOM (CycloneDX)
+        run: npm sbom --sbom-format=cyclonedx --sbom-type=library --omit dev > sbom.cdx.json
+
+      - name: Build immutable publication bundle
+        id: bundle
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          PACK_JSON="$(npm pack --ignore-scripts --json)"
+          TARBALL_NAME="$(jq -er 'if length == 1 then .[0].filename else empty end' <<<"${PACK_JSON}")"
+          if [ "$(basename "${TARBALL_NAME}")" != "${TARBALL_NAME}" ] || ! printf '%s' "${TARBALL_NAME}" | grep -Eq '^[0-9A-Za-z._-]+\.tgz$'; then
+            echo "npm pack returned an unsafe tarball name: ${TARBALL_NAME}" >&2
+            exit 1
+          fi
+          if [ ! -f "${TARBALL_NAME}" ] || [ -L "${TARBALL_NAME}" ]; then
+            echo "Expected one regular, non-symlink package tarball: ${TARBALL_NAME}" >&2
+            exit 1
+          fi
+          if [ ! -f sbom.cdx.json ] || [ -L sbom.cdx.json ]; then
+            echo "Expected a regular, non-symlink SBOM." >&2
+            exit 1
+          fi
+          jq -e . sbom.cdx.json >/dev/null
+
+          TARBALL_SHA256="$(sha256sum "${TARBALL_NAME}" | awk '{print $1}')"
+          SBOM_SHA256="$(sha256sum sbom.cdx.json | awk '{print $1}')"
+          for DIGEST in "${TARBALL_SHA256}" "${SBOM_SHA256}"; do
+            if ! printf '%s' "${DIGEST}" | grep -Eq '^[0-9a-f]{64}$'; then
+              echo "Publication bundle SHA-256 generation failed." >&2
+              exit 1
+            fi
+          done
+
+          {
+            echo "tarball_name=${TARBALL_NAME}"
+            echo "tarball_sha256=${TARBALL_SHA256}"
+            echo "sbom_sha256=${SBOM_SHA256}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Upload immutable package tarball
+        id: upload_package
+        uses: actions/upload-artifact@v7
+        with:
+          path: ${{ steps.bundle.outputs.tarball_name }}
+          archive: false
+          retention-days: 1
+
+      - name: Upload immutable SBOM
+        id: upload_sbom
+        uses: actions/upload-artifact@v7
+        with:
+          path: sbom.cdx.json
+          archive: false
+          retention-days: 1
+
       - name: Locate coverage report for Codecov
         id: codecov_coverage
-        if: steps.release.outputs.should_finalize_release == 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -204,7 +436,7 @@ jobs:
 
       - name: Upload coverage to Codecov (best effort)
         id: codecov
-        if: steps.release.outputs.should_finalize_release == 'true' && steps.codecov_coverage.outputs.available == 'true'
+        if: steps.codecov_coverage.outputs.available == 'true'
         continue-on-error: true
         uses: codecov/codecov-action@v4
         with:
@@ -216,125 +448,559 @@ jobs:
 
       - name: Report Codecov upload warning
         if: always() && steps.codecov.outcome == 'failure'
-        run: echo "::warning title=Codecov upload unavailable::Release coverage upload failed or was quota-limited; release validation and publication will continue."
+        run: echo "::warning title=Codecov upload unavailable::Release coverage upload failed or was quota-limited; immutable publication artifacts were already sealed and remain unchanged."
 
-      - name: Generate SBOM (CycloneDX)
-        if: steps.release.outputs.should_finalize_release == 'true'
-        run: npm sbom --sbom-format=cyclonedx --sbom-type=library --omit dev > sbom.cdx.json
-
-      - name: Attest SBOM
-        if: steps.release.outputs.should_finalize_release == 'true' && hashFiles('sbom.cdx.json') != ''
-        uses: actions/attest-build-provenance@v3
+  publish:
+    if: inputs.phase == 'publish'
+    needs: validate_and_pack
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      actions: read
+      attestations: write
+      contents: write
+      id-token: write
+    steps:
+      - name: Checkout exact workflow commit
+        uses: actions/checkout@v6
         with:
-          subject-path: sbom.cdx.json
+          ref: ${{ github.sha }}
+          fetch-depth: 0
 
-      - name: Ensure release tag points at prepared commit
-        if: steps.release.outputs.should_finalize_release == 'true'
+      - name: Use Node.js 24.18.0
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+          package-manager-cache: false
+
+      - name: Install pinned npm release client
+        run: npm install --global npm@11.6.2 --ignore-scripts --registry https://registry.npmjs.org
+
+      - name: Verify release runtime
+        run: |
+          set -euo pipefail
+
+          EXPECTED_NODE="$(tr -d '[:space:]' < .nvmrc)"
+          ACTUAL_NODE="$(node --version | sed 's/^v//')"
+          if [ "${ACTUAL_NODE%%.*}" != "24" ]; then
+            echo "Expected Node.js 24, found ${ACTUAL_NODE}." >&2
+            exit 1
+          fi
+          if [ "${EXPECTED_NODE}" != "24.18.0" ] || [ "${ACTUAL_NODE}" != "${EXPECTED_NODE}" ]; then
+            echo "Expected Node.js 24.18.0, found ${ACTUAL_NODE} with .nvmrc=${EXPECTED_NODE}." >&2
+            exit 1
+          fi
+
+          ACTUAL_NPM="$(npm --version)"
+          node - "${ACTUAL_NPM}" <<'NODE'
+          const actual = process.argv[2].split(".").map(Number);
+          const minimum = "11.5.1".split(".").map(Number);
+          for (let index = 0; index < 3; index += 1) {
+            if (actual[index] > minimum[index]) process.exit(0);
+            if (actual[index] < minimum[index]) process.exit(1);
+          }
+          process.exit(0);
+          NODE
+
+          echo "Using Node.js ${ACTUAL_NODE} and npm ${ACTUAL_NPM}."
+
+      - name: Enforce exact-main release identity
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ steps.release.outputs.release_tag }}
-          PUBLISHED: ${{ needs.prepare_release.outputs.published }}
+          EXPECTED_SHA: ${{ inputs.expected_commit_sha }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          if ! printf '%s' "${EXPECTED_SHA}" | grep -Eq '^[0-9a-f]{40}$'; then
+            echo "Publish requires a full expected_commit_sha." >&2
+            exit 1
+          fi
+          if [ -z "${RELEASE_TAG}" ]; then
+            echo "Publish requires release_tag." >&2
+            exit 1
+          fi
+          if [ '${{ github.ref }}' != "refs/heads/main" ]; then
+            echo "Publication must be dispatched from refs/heads/main." >&2
+            exit 1
+          fi
+          if [ '${{ github.sha }}' != "${EXPECTED_SHA}" ]; then
+            echo "Workflow SHA ${{ github.sha }} does not match prepared SHA ${EXPECTED_SHA}." >&2
+            exit 1
+          fi
+
+          git fetch origin main --no-tags
+          REMOTE_MAIN="$(git rev-parse refs/remotes/origin/main)"
+          if [ "${REMOTE_MAIN}" != "${EXPECTED_SHA}" ]; then
+            echo "Remote main ${REMOTE_MAIN} does not match prepared SHA ${EXPECTED_SHA}." >&2
+            exit 1
+          fi
+          git merge-base --is-ancestor "${EXPECTED_SHA}" refs/remotes/origin/main
+
+          RUNS="$(
+            gh api -X GET \
+              "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs" \
+              -f branch=main \
+              -f event=push \
+              -f head_sha="${EXPECTED_SHA}" \
+              -f status=success \
+              -f per_page=100
+          )"
+          MATCHES="$(
+            jq \
+              --arg sha "${EXPECTED_SHA}" \
+              '[.workflow_runs[] | select(
+                .head_sha == $sha and
+                .head_branch == "main" and
+                .event == "push" and
+                .status == "completed" and
+                .conclusion == "success"
+              )] | length' \
+              <<<"${RUNS}"
+          )"
+          if [ "${MATCHES}" -le 0 ]; then
+            echo "No successful exact-SHA main push CI exists for ${EXPECTED_SHA}." >&2
+            exit 1
+          fi
+
+      - name: Download exact package artifact
+        uses: actions/download-artifact@v8
+        with:
+          artifact-ids: ${{ needs.validate_and_pack.outputs.tarball_artifact_id }}
+          path: release-package
+          digest-mismatch: error
+
+      - name: Download exact SBOM artifact
+        uses: actions/download-artifact@v8
+        with:
+          artifact-ids: ${{ needs.validate_and_pack.outputs.sbom_artifact_id }}
+          path: release-sbom
+          digest-mismatch: error
+
+      - name: Verify immutable publication bundle
+        id: release
+        env:
+          EXPECTED_PACKAGE_NAME: ${{ needs.validate_and_pack.outputs.package_name }}
+          EXPECTED_VERSION: ${{ needs.validate_and_pack.outputs.release_version }}
+          EXPECTED_TAG: ${{ needs.validate_and_pack.outputs.release_tag }}
+          EXPECTED_PREID: ${{ needs.validate_and_pack.outputs.effective_preid }}
+          EXPECTED_TARBALL_NAME: ${{ needs.validate_and_pack.outputs.tarball_name }}
+          EXPECTED_TARBALL_SHA256: ${{ needs.validate_and_pack.outputs.tarball_sha256 }}
+          EXPECTED_TARBALL_ARTIFACT_DIGEST: ${{ needs.validate_and_pack.outputs.tarball_artifact_digest }}
+          EXPECTED_SBOM_SHA256: ${{ needs.validate_and_pack.outputs.sbom_sha256 }}
+          EXPECTED_SBOM_ARTIFACT_DIGEST: ${{ needs.validate_and_pack.outputs.sbom_artifact_digest }}
+          RELEASE_TAG_INPUT: ${{ inputs.release_tag }}
+          PREID_INPUT: ${{ inputs.preid }}
+        run: |
+          set -euo pipefail
+
+          mapfile -t PACKAGE_ENTRIES < <(find release-package -mindepth 1 -maxdepth 1 -print)
+          mapfile -t SBOM_ENTRIES < <(find release-sbom -mindepth 1 -maxdepth 1 -print)
+          if [ "${#PACKAGE_ENTRIES[@]}" -ne 1 ] || [ "${#SBOM_ENTRIES[@]}" -ne 1 ]; then
+            echo "Each publication artifact ID must resolve to exactly one file." >&2
+            exit 1
+          fi
+
+          TARBALL="${PACKAGE_ENTRIES[0]}"
+          SBOM="${SBOM_ENTRIES[0]}"
+          if [ ! -f "${TARBALL}" ] || [ -L "${TARBALL}" ] || [ ! -f "${SBOM}" ] || [ -L "${SBOM}" ]; then
+            echo "Publication artifacts must be regular, non-symlink files." >&2
+            exit 1
+          fi
+          if [ "$(basename "${TARBALL}")" != "${EXPECTED_TARBALL_NAME}" ] || [ "$(basename "${SBOM}")" != "sbom.cdx.json" ]; then
+            echo "Downloaded publication artifact names do not match the immutable hand-off." >&2
+            exit 1
+          fi
+
+          TARBALL_SHA256="$(sha256sum "${TARBALL}" | awk '{print $1}')"
+          SBOM_SHA256="$(sha256sum "${SBOM}" | awk '{print $1}')"
+          if [ "${TARBALL_SHA256}" != "${EXPECTED_TARBALL_SHA256}" ] || [ "${SBOM_SHA256}" != "${EXPECTED_SBOM_SHA256}" ]; then
+            echo "Downloaded publication artifact SHA-256 does not match the read-only build job." >&2
+            exit 1
+          fi
+          for ARTIFACT_DIGEST in "${EXPECTED_TARBALL_ARTIFACT_DIGEST}" "${EXPECTED_SBOM_ARTIFACT_DIGEST}"; do
+            if ! printf '%s' "${ARTIFACT_DIGEST}" | grep -Eq '^[0-9a-f]{64}$'; then
+              echo "GitHub artifact digests were not bound into the publication hand-off." >&2
+              exit 1
+            fi
+          done
+          jq -e . "${SBOM}" >/dev/null
+
+          while IFS= read -r MEMBER; do
+            case "${MEMBER}" in
+              package | package/*) ;;
+              *)
+                echo "Unsafe package member outside package/: ${MEMBER}" >&2
+                exit 1
+                ;;
+            esac
+            case "${MEMBER}" in
+              /* | ../* | */../* | */..)
+                echo "Unsafe package traversal member: ${MEMBER}" >&2
+              exit 1
+              ;;
+            esac
+          done < <(tar -tzf "${TARBALL}")
+
+          if ! tar -tzf "${TARBALL}" | node -e '
+            const fs = require("node:fs");
+            const path = require("node:path");
+            const prohibited = "legal/cla-registry.csv";
+            const normalizeArtifactPath = (value) => {
+              const normalized = path.posix
+                .normalize(String(value).replaceAll("\\", "/"))
+                .replace(/^(?:\.\/)+/u, "")
+                .normalize("NFKC")
+                .toLocaleLowerCase("en-US");
+              return normalized.startsWith("package/")
+                ? normalized.slice("package/".length)
+                : normalized;
+            };
+            const members = fs
+              .readFileSync(0, "utf8")
+              .split(/\r?\n/u)
+              .filter(Boolean);
+            if (
+              members.some(
+                (member) => normalizeArtifactPath(member) === prohibited,
+              )
+            ) {
+              process.exit(1);
+            }
+          '; then
+            echo "Package tarball contains prohibited path metadata." >&2
+            exit 1
+          fi
+
+          if ! tar -tzf "${TARBALL}" | grep -E '^package/dist(/|$)' >/dev/null; then
+            echo "Package tarball is missing built dist output." >&2
+            exit 1
+          fi
+
+          PACKED_METADATA="$(tar -xOzf "${TARBALL}" package/package.json | jq -er '[.name, .version] | @tsv')"
+          IFS=$'\t' read -r PACKED_NAME PACKED_VERSION <<<"${PACKED_METADATA}"
+          SOURCE_NAME="$(node -p "require('./package.json').name || ''")"
+          SOURCE_VERSION="$(node -p "require('./package.json').version || ''")"
+          SOURCE_TAG="v${SOURCE_VERSION}"
+          if [ "${SOURCE_NAME}" != "${EXPECTED_PACKAGE_NAME}" ] || [ "${PACKED_NAME}" != "${EXPECTED_PACKAGE_NAME}" ]; then
+            echo "Package name differs across source, bundle, and hand-off." >&2
+            exit 1
+          fi
+          if [ "${SOURCE_VERSION}" != "${EXPECTED_VERSION}" ] || [ "${PACKED_VERSION}" != "${EXPECTED_VERSION}" ]; then
+            echo "Package version differs across source, bundle, and hand-off." >&2
+            exit 1
+          fi
+          if [ "${SOURCE_TAG}" != "${EXPECTED_TAG}" ] || [ "${RELEASE_TAG_INPUT}" != "${EXPECTED_TAG}" ]; then
+            echo "Release tag differs across source, bundle, and dispatch hand-off." >&2
+            exit 1
+          fi
+
+          DERIVED_PREID=$(PACKAGE_VERSION="${SOURCE_VERSION}" node -e '
+          const version = process.env.PACKAGE_VERSION || "";
+          const match = version.match(/^[0-9]+\.[0-9]+\.[0-9]+(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/);
+          if (!match) process.exit(1);
+          const identifiers = match[1] ? match[1].split(".") : [];
+          if (identifiers.length > 1 && /^[0-9]+$/.test(identifiers.at(-1))) identifiers.pop();
+          process.stdout.write(identifiers.join("."));
+          ')
+          if [ "${DERIVED_PREID}" != "${EXPECTED_PREID}" ] || [ "${PREID_INPUT}" != "${EXPECTED_PREID}" ]; then
+            echo "Pre-release identity differs across source, bundle, and dispatch hand-off." >&2
+            exit 1
+          fi
+
+          DIST_TAG="latest"
+          if [ -n "${DERIVED_PREID}" ]; then
+            DIST_TAG="${DERIVED_PREID}"
+          fi
+          TARBALL_INTEGRITY="sha512-$(openssl dgst -sha512 -binary "${TARBALL}" | openssl base64 -A)"
+          if ! printf '%s' "${TARBALL_INTEGRITY}" | grep -Eq '^sha512-[A-Za-z0-9+/]+={0,2}$'; then
+            echo "Could not derive a SHA-512 SRI value for the immutable package tarball." >&2
+            exit 1
+          fi
+
+          SHOULD_PUBLISH_NPM="true"
+          if npm view "${SOURCE_NAME}@${SOURCE_VERSION}" version --registry https://registry.npmjs.org >/dev/null 2>&1; then
+            REGISTRY_INTEGRITY="$(
+              npm view \
+                "${SOURCE_NAME}@${SOURCE_VERSION}" \
+                dist.integrity \
+                --registry https://registry.npmjs.org \
+                --prefer-online \
+                --json |
+                jq -er 'if type == "string" and length > 0 then . else empty end'
+            )"
+            if [ "${REGISTRY_INTEGRITY}" != "${TARBALL_INTEGRITY}" ]; then
+              echo "Existing npm package integrity does not match the immutable publication tarball." >&2
+              exit 1
+            fi
+
+            REGISTRY_DIST_TAG_VERSION="$(
+              npm view \
+                "${SOURCE_NAME}" \
+                dist-tags \
+                --registry https://registry.npmjs.org \
+                --prefer-online \
+                --json |
+                jq -er --arg tag "${DIST_TAG}" '.[$tag] // empty'
+            )"
+            if [ "${REGISTRY_DIST_TAG_VERSION}" != "${SOURCE_VERSION}" ]; then
+              echo "Existing npm distribution tag does not point at the exact package version." >&2
+              exit 1
+            fi
+
+            SHOULD_PUBLISH_NPM="false"
+          fi
+
+          {
+            echo "package_name=${SOURCE_NAME}"
+            echo "release_version=${SOURCE_VERSION}"
+            echo "release_tag=${SOURCE_TAG}"
+            echo "effective_preid=${DERIVED_PREID}"
+            echo "should_publish_npm=${SHOULD_PUBLISH_NPM}"
+            echo "dist_tag=${DIST_TAG}"
+            echo "tarball_integrity=${TARBALL_INTEGRITY}"
+            echo "tarball_path=${TARBALL}"
+            echo "sbom_path=${SBOM}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Revalidate exact main immediately before release mutation
+        env:
+          EXPECTED_SHA: ${{ inputs.expected_commit_sha }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
           HEAD_SHA="$(git rev-parse HEAD)"
-          git fetch origin --tags --force
-
-          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
-            git fetch origin "refs/tags/${TAG}:refs/tags/${TAG}" --force
-            TAG_SHA="$(git rev-list -n 1 "${TAG}")"
-            if [ "${TAG_SHA}" = "${HEAD_SHA}" ]; then
-              echo "Tag ${TAG} already points at prepared commit ${HEAD_SHA}."
-              exit 0
-            fi
-
-            if [ "${PUBLISHED}" = "true" ]; then
-              echo "Package is already published; preserving existing tag ${TAG} at ${TAG_SHA}."
-              exit 0
-            fi
-
-            if gh release view "${TAG}" >/dev/null 2>&1; then
-              IS_DRAFT="$(gh release view "${TAG}" --json isDraft --jq '.isDraft')"
-              if [ "${IS_DRAFT}" != "true" ]; then
-                echo "Release ${TAG} already exists and is published at ${TAG_SHA}; cut a new version instead." >&2
-                exit 1
-              fi
-            fi
-
-            echo "Replacing stale unpublished tag ${TAG}."
-            git push origin ":refs/tags/${TAG}"
-            git tag -d "${TAG}" >/dev/null 2>&1 || true
-          elif [ "${PUBLISHED}" = "true" ]; then
-            echo "Package is already published but tag ${TAG} is missing; cannot safely recreate a release tag after npm publication." >&2
+          if [ "${HEAD_SHA}" != "${EXPECTED_SHA}" ]; then
+            echo "Checked-out release commit ${HEAD_SHA} differs from ${EXPECTED_SHA}." >&2
             exit 1
           fi
 
-          git tag "${TAG}" "${HEAD_SHA}"
-          git push origin "${TAG}"
+          git fetch origin main --no-tags
+          REMOTE_MAIN="$(git rev-parse refs/remotes/origin/main)"
+          if [ "${REMOTE_MAIN}" != "${EXPECTED_SHA}" ]; then
+            echo "main moved to ${REMOTE_MAIN}; refusing to mutate release state for ${EXPECTED_SHA}." >&2
+            exit 1
+          fi
+
+          RUNS="$(
+            gh api -X GET \
+              "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs" \
+              -f branch=main \
+              -f event=push \
+              -f head_sha="${EXPECTED_SHA}" \
+              -f status=success \
+              -f per_page=100
+          )"
+          MATCHES="$(
+            jq \
+              --arg sha "${EXPECTED_SHA}" \
+              '[.workflow_runs[] | select(
+                .head_sha == $sha and
+                .head_branch == "main" and
+                .event == "push" and
+                .status == "completed" and
+                .conclusion == "success"
+              )] | length' \
+              <<<"${RUNS}"
+          )"
+          if [ "${MATCHES}" -le 0 ]; then
+            echo "Exact-SHA CI evidence disappeared for ${EXPECTED_SHA}; refusing release mutation." >&2
+            exit 1
+          fi
+
+      - name: Ensure release tag points at exact main commit
+        env:
+          EXPECTED_SHA: ${{ inputs.expected_commit_sha }}
+          TAG: ${{ steps.release.outputs.release_tag }}
+          PACKAGE_PUBLISHED: ${{ steps.release.outputs.should_publish_npm != 'true' }}
+        run: |
+          set -euo pipefail
+
+          git fetch origin --tags
+          REMOTE_TAG_SHA="$(git ls-remote origin "refs/tags/${TAG}" | awk 'NR == 1 { print $1 }')"
+          if [ -n "${REMOTE_TAG_SHA}" ]; then
+            if [ "${REMOTE_TAG_SHA}" != "${EXPECTED_SHA}" ]; then
+              echo "Tag ${TAG} points at ${REMOTE_TAG_SHA}, expected ${EXPECTED_SHA}; refusing to rewrite it." >&2
+              exit 1
+            fi
+            echo "Tag ${TAG} already points at ${EXPECTED_SHA}."
+            exit 0
+          fi
+
+          if [ "${PACKAGE_PUBLISHED}" = "true" ]; then
+            echo "Package version already exists but tag ${TAG} is absent; refusing to reconstruct release identity." >&2
+            exit 1
+          fi
+
+          git tag "${TAG}" "${EXPECTED_SHA}"
+          git push origin "refs/tags/${TAG}"
 
       - name: Create GitHub Release draft
-        if: steps.release.outputs.should_finalize_release == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.release.outputs.release_tag }}
-          PREID: ${{ inputs.preid }}
+          PREID: ${{ steps.release.outputs.effective_preid }}
+          SBOM: ${{ steps.release.outputs.sbom_path }}
         run: |
           set -euo pipefail
 
+          EXPECTED_PRERELEASE="false"
+          if [ -n "${PREID}" ]; then
+            EXPECTED_PRERELEASE="true"
+          fi
+
           if gh release view "${TAG}" >/dev/null 2>&1; then
-            IS_DRAFT="$(gh release view "${TAG}" --json isDraft --jq '.isDraft')"
+            RELEASE_STATE="$(gh release view "${TAG}" --json isDraft,isPrerelease --jq '[.isDraft, .isPrerelease] | map(tostring) | join(" ")')"
+            read -r IS_DRAFT IS_PRERELEASE <<<"${RELEASE_STATE}"
+            if [ "${IS_PRERELEASE}" != "${EXPECTED_PRERELEASE}" ]; then
+              echo "Published release ${TAG} does not match the version-derived prerelease state ${EXPECTED_PRERELEASE}." >&2
+              exit 1
+            fi
             if [ "${IS_DRAFT}" != "true" ]; then
-              echo "Release ${TAG} is already published; nothing to recover."
+              echo "Release ${TAG} is already published with the expected prerelease state."
               exit 0
             fi
 
-            if [ -s sbom.cdx.json ]; then
-              gh release upload "${TAG}" sbom.cdx.json --clobber
+            if [ -s "${SBOM}" ]; then
+              gh release upload "${TAG}" "${SBOM}" --clobber
             fi
-            exit 0
-          fi
-
-          ARGS=(--title "Release ${TAG}" --generate-notes --verify-tag --draft)
-          if [ -n "${PREID}" ]; then
-            ARGS+=(--prerelease)
-          fi
-
-          if [ -s sbom.cdx.json ]; then
-            gh release create "${TAG}" sbom.cdx.json "${ARGS[@]}"
           else
-            gh release create "${TAG}" "${ARGS[@]}"
+            ARGS=(--title "Release ${TAG}" --generate-notes --verify-tag --draft)
+            if [ -n "${PREID}" ]; then
+              ARGS+=(--prerelease)
+            fi
+
+            if [ -s "${SBOM}" ]; then
+              gh release create "${TAG}" "${SBOM}" "${ARGS[@]}"
+            else
+              gh release create "${TAG}" "${ARGS[@]}"
+            fi
           fi
 
-      - name: Publish package
+      - name: Attest immutable package tarball
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: ${{ steps.release.outputs.tarball_path }}
+
+      - name: Attest immutable SBOM
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: ${{ steps.release.outputs.sbom_path }}
+
+      - name: Revalidate exact main immediately before npm publication
         if: steps.release.outputs.should_publish_npm == 'true'
         env:
-          FLAGS: ${{ steps.release.outputs.flags }}
-          PACKAGE_NAME: ${{ steps.release.outputs.package_name }}
-          PACKAGE_VERSION: ${{ steps.release.outputs.release_version }}
+          EXPECTED_SHA: ${{ inputs.expected_commit_sha }}
         run: |
           set -euo pipefail
-          if npm view "${PACKAGE_NAME}@${PACKAGE_VERSION}" version --registry https://registry.npmjs.org >/dev/null 2>&1; then
-            echo "${PACKAGE_NAME}@${PACKAGE_VERSION} already exists on npm; skipping duplicate publish."
-            exit 0
+
+          HEAD_SHA="$(git rev-parse HEAD)"
+          if [ "${HEAD_SHA}" != "${EXPECTED_SHA}" ]; then
+            echo "Checked-out release commit ${HEAD_SHA} differs from ${EXPECTED_SHA}." >&2
+            exit 1
           fi
 
-          npm publish ${FLAGS} --provenance --registry https://registry.npmjs.org
+          git fetch origin main --no-tags
+          REMOTE_MAIN="$(git rev-parse refs/remotes/origin/main)"
+          if [ "${REMOTE_MAIN}" != "${EXPECTED_SHA}" ]; then
+            echo "main moved to ${REMOTE_MAIN}; refusing npm publication for ${EXPECTED_SHA}." >&2
+            exit 1
+          fi
 
-      - name: Publish GitHub Release
-        if: steps.release.outputs.should_finalize_release == 'true'
+      - name: Publish package through npm OIDC
+        if: steps.release.outputs.should_publish_npm == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ steps.release.outputs.release_tag }}
-          PREID: ${{ inputs.preid }}
+          DIST_TAG: ${{ steps.release.outputs.dist_tag }}
+          TARBALL: ${{ steps.release.outputs.tarball_path }}
         run: |
           set -euo pipefail
+
+          PUBLISH_ARGS=(--access public --provenance --registry https://registry.npmjs.org --tag "${DIST_TAG}")
+          npm publish "./${TARBALL}" --ignore-scripts "${PUBLISH_ARGS[@]}"
+
+      - name: Skip duplicate npm publication
+        if: steps.release.outputs.should_publish_npm != 'true'
+        run: echo "${{ steps.release.outputs.package_name }}@${{ steps.release.outputs.release_version }} is already published; continuing idempotent GitHub release finalization."
+
+      - name: Verify exact npm registry publication
+        env:
+          PACKAGE_NAME: ${{ steps.release.outputs.package_name }}
+          PACKAGE_VERSION: ${{ steps.release.outputs.release_version }}
+          EXPECTED_DIST_TAG: ${{ steps.release.outputs.dist_tag }}
+          EXPECTED_INTEGRITY: ${{ steps.release.outputs.tarball_integrity }}
+        run: |
+          set -euo pipefail
+
+          DEADLINE=$((SECONDS + 300))
+          while [ "${SECONDS}" -lt "${DEADLINE}" ]; do
+            REGISTRY_INTEGRITY="$(
+              npm view \
+                "${PACKAGE_NAME}@${PACKAGE_VERSION}" \
+                dist.integrity \
+                --registry https://registry.npmjs.org \
+                --prefer-online \
+                --json 2>/dev/null |
+                jq -er 'if type == "string" and length > 0 then . else empty end' 2>/dev/null ||
+                true
+            )"
+            if [ -n "${REGISTRY_INTEGRITY}" ] && [ "${REGISTRY_INTEGRITY}" != "${EXPECTED_INTEGRITY}" ]; then
+              echo "Published npm package integrity differs from the attested immutable tarball." >&2
+              exit 1
+            fi
+
+            REGISTRY_DIST_TAG_VERSION="$(
+              npm view \
+                "${PACKAGE_NAME}" \
+                dist-tags \
+                --registry https://registry.npmjs.org \
+                --prefer-online \
+                --json 2>/dev/null |
+                jq -er --arg tag "${EXPECTED_DIST_TAG}" '.[$tag] // empty' 2>/dev/null ||
+                true
+            )"
+            if [ "${REGISTRY_INTEGRITY}" = "${EXPECTED_INTEGRITY}" ] && [ "${REGISTRY_DIST_TAG_VERSION}" = "${PACKAGE_VERSION}" ]; then
+              echo "npm registry contains the exact immutable tarball and expected distribution tag."
+              exit 0
+            fi
+
+            sleep 5
+          done
+
+          echo "npm registry did not expose the exact immutable tarball and expected distribution tag within 300 seconds." >&2
+          exit 1
+
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.release.outputs.release_tag }}
+          PREID: ${{ steps.release.outputs.effective_preid }}
+        run: |
+          set -euo pipefail
+
           if ! gh release view "${TAG}" >/dev/null 2>&1; then
-            echo "Expected draft release ${TAG} to exist before publication." >&2
+            echo "Expected release ${TAG} to exist before finalization." >&2
             exit 1
+          fi
+
+          EXPECTED_PRERELEASE="false"
+          if [ -n "${PREID}" ]; then
+            EXPECTED_PRERELEASE="true"
+          fi
+
+          RELEASE_STATE="$(gh release view "${TAG}" --json isDraft,isPrerelease --jq '[.isDraft, .isPrerelease] | map(tostring) | join(" ")')"
+          read -r IS_DRAFT IS_PRERELEASE <<<"${RELEASE_STATE}"
+          if [ "${IS_PRERELEASE}" != "${EXPECTED_PRERELEASE}" ]; then
+            echo "Published release ${TAG} does not match the version-derived prerelease state ${EXPECTED_PRERELEASE}." >&2
+            exit 1
+          fi
+          if [ "${IS_DRAFT}" != "true" ]; then
+            echo "Release ${TAG} is already published with the expected prerelease state."
+            exit 0
           fi
 
           if [ -n "${PREID}" ]; then
             gh release edit "${TAG}" --draft=false --prerelease
           else
-            gh release edit "${TAG}" --draft=false --latest
+            gh release edit "${TAG}" --draft=false --latest --prerelease=false
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  pull_request:
+    branches: [main]
   push:
     branches: [main]
 permissions:
@@ -13,6 +15,7 @@ env:
 
 jobs:
   build-test:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -40,6 +40,10 @@ on:
         required: false
         type: string
         default: "1200"
+    secrets:
+      RELEASE_PREP_APP_PRIVATE_KEY:
+        description: "Private key for the narrowly scoped release-preparation GitHub App."
+        required: true
     outputs:
       name:
         description: "npm package name"
@@ -59,11 +63,12 @@ on:
       commit_sha:
         description: "main commit containing the release metadata"
         value: ${{ jobs.prepare.outputs.commit_sha }}
+      effective_preid:
+        description: "npm distribution tag identity derived from the prepared package version"
+        value: ${{ jobs.prepare.outputs.effective_preid }}
 
 permissions:
-  contents: write
-  pull-requests: write
-  actions: read
+  contents: read
 
 jobs:
   prepare:
@@ -76,12 +81,14 @@ jobs:
       flags: ${{ steps.release.outputs.flags }}
       published: ${{ steps.release.outputs.published }}
       commit_sha: ${{ steps.release.outputs.commit_sha }}
+      effective_preid: ${{ steps.release.outputs.effective_preid }}
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.base_branch }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Create release-prep GitHub App token
         id: release_prep_app_token
@@ -93,10 +100,10 @@ jobs:
           permission-pull-requests: write
 
       - name: Use Node.js 24
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
-          cache: 'npm'
+          package-manager-cache: false
 
       - name: Prepare and land release metadata
         id: release
@@ -283,9 +290,9 @@ jobs:
           process.stdout.write(version);
           ' "${CURRENT_VER}" "${REGISTRY_VER}" "${TAG_VER}" "${BUMP}" "${PREID:-}")
             if [ "${PACKAGE_DIRECTORY}" = "." ]; then
-              npm version "${TARGET_VER}" --no-git-tag-version --allow-same-version
+              npm version "${TARGET_VER}" --ignore-scripts --no-git-tag-version --allow-same-version
             else
-              npm version "${TARGET_VER}" --workspace "${PACKAGE_DIRECTORY}" --no-git-tag-version --allow-same-version
+              npm version "${TARGET_VER}" --workspace "${PACKAGE_DIRECTORY}" --ignore-scripts --no-git-tag-version --allow-same-version
             fi
           fi
 
@@ -382,58 +389,47 @@ jobs:
           else
             git commit -m "chore: prepare release ${TAG}"
 
-            if git push origin "HEAD:${BASE_BRANCH}"; then
-              echo "Release metadata pushed directly to ${BASE_BRANCH}."
-            else
-              BRANCH="release/${TAG}"
-              git remote set-url origin "https://x-access-token:${RELEASE_PREP_AUTH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-              git fetch origin "refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}" || true
-              git push --force-with-lease --set-upstream origin "HEAD:${BRANCH}"
+            BRANCH="release/${TAG}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+            git push --set-upstream origin "HEAD:${BRANCH}"
 
-              PR_TITLE="chore: prepare release ${TAG}"
-              PR_BODY=$(cat <<EOF
+            PR_TITLE="chore: prepare release ${TAG}"
+            PR_BODY=$(cat <<EOF
           ## Summary
           - prepare \`${TAG}\` for publication from protected \`${BASE_BRANCH}\`
           - update package metadata to \`${TARGET_VER}\`
           - move the current \`Unreleased\` notes into \`${TARGET_VER}\`
 
-          The CD workflow will continue only after this release metadata is present on \`${BASE_BRANCH}\`.
+          The CD workflow will continue only after this release metadata is merged into \`${BASE_BRANCH}\` and exact-commit CI succeeds.
           EOF
           )
 
-              PR_NUMBER="$(gh pr list --head "${BRANCH}" --base "${BASE_BRANCH}" --state open --json number --jq '.[0].number' || true)"
-              if [ -n "${PR_NUMBER}" ] && [ "${PR_NUMBER}" != "null" ]; then
-                gh pr edit "${PR_NUMBER}" --title "${PR_TITLE}" --body "${PR_BODY}"
-              else
-                PR_URL="$(gh pr create --base "${BASE_BRANCH}" --head "${BRANCH}" --title "${PR_TITLE}" --body "${PR_BODY}")"
-                PR_NUMBER="$(gh pr view "${PR_URL}" --json number --jq '.number')"
-              fi
+            PR_URL="$(gh pr create --base "${BASE_BRANCH}" --head "${BRANCH}" --title "${PR_TITLE}" --body "${PR_BODY}")"
+            PR_NUMBER="$(gh pr view "${PR_URL}" --json number --jq '.number')"
 
-              if gh pr merge "${PR_NUMBER}" --squash --delete-branch; then
-                echo "Release metadata PR #${PR_NUMBER} merged."
-              else
-                echo "Immediate merge was not available for release metadata PR #${PR_NUMBER}; enabling auto-merge and waiting."
-                gh pr merge "${PR_NUMBER}" --auto --squash --delete-branch || true
+            if gh pr merge "${PR_NUMBER}" --squash --delete-branch; then
+              echo "Release metadata PR #${PR_NUMBER} merged."
+            else
+              echo "Immediate merge was not available for release metadata PR #${PR_NUMBER}; enabling auto-merge and waiting."
+              gh pr merge "${PR_NUMBER}" --auto --squash --delete-branch || true
 
-                DEADLINE=$((SECONDS + MERGE_TIMEOUT_SECONDS))
-                while [ "${SECONDS}" -lt "${DEADLINE}" ]; do
-                  STATE="$(gh pr view "${PR_NUMBER}" --json state --jq '.state')"
-                  if [ "${STATE}" = "MERGED" ]; then
-                    echo "Release metadata PR #${PR_NUMBER} merged."
-                    break
-                  fi
-                  if [ "${STATE}" = "CLOSED" ]; then
-                    echo "Release metadata PR #${PR_NUMBER} closed without merging." >&2
-                    exit 1
-                  fi
-                  sleep 10
-                done
-
+              DEADLINE=$((SECONDS + MERGE_TIMEOUT_SECONDS))
+              while [ "${SECONDS}" -lt "${DEADLINE}" ]; do
                 STATE="$(gh pr view "${PR_NUMBER}" --json state --jq '.state')"
-                if [ "${STATE}" != "MERGED" ]; then
-                  echo "Release metadata PR #${PR_NUMBER} did not merge within ${MERGE_TIMEOUT_SECONDS}s; release will not continue until ${BASE_BRANCH} contains ${TAG}." >&2
+                if [ "${STATE}" = "MERGED" ]; then
+                  echo "Release metadata PR #${PR_NUMBER} merged."
+                  break
+                fi
+                if [ "${STATE}" = "CLOSED" ]; then
+                  echo "Release metadata PR #${PR_NUMBER} closed without merging." >&2
                   exit 1
                 fi
+                sleep 10
+              done
+
+              STATE="$(gh pr view "${PR_NUMBER}" --json state --jq '.state')"
+              if [ "${STATE}" != "MERGED" ]; then
+                echo "Release metadata PR #${PR_NUMBER} did not merge within ${MERGE_TIMEOUT_SECONDS}s; release will not continue until ${BASE_BRANCH} contains ${TAG}." >&2
+                exit 1
               fi
             fi
           fi
@@ -458,13 +454,23 @@ jobs:
             FLAGS="--access public"
           fi
 
-          EFFECTIVE_PREID="${PREID:-}"
-          if [ -z "${EFFECTIVE_PREID}" ]; then
-            EFFECTIVE_PREID=$(TARGET_VER="${TARGET_VER}" node -e '
+          EFFECTIVE_PREID=$(TARGET_VER="${MAIN_VERSION}" node -e '
           const version = process.env.TARGET_VER || "";
-          const match = version.match(/^[0-9]+\.[0-9]+\.[0-9]+-([0-9A-Za-z][0-9A-Za-z.-]*)\.[0-9]+$/);
-          process.stdout.write(match ? match[1] : "");
+          const match = version.match(/^[0-9]+\.[0-9]+\.[0-9]+(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/);
+          if (!match) {
+            console.error(`Cannot derive pre-release identity from invalid version ${version}.`);
+            process.exit(1);
+          }
+          const identifiers = match[1] ? match[1].split(".") : [];
+          if (identifiers.length > 1 && /^[0-9]+$/.test(identifiers.at(-1))) {
+            identifiers.pop();
+          }
+          process.stdout.write(identifiers.join("."));
           ')
+
+          if [ -n "${PREID:-}" ] && [ "${PREID}" != "${EFFECTIVE_PREID}" ]; then
+            echo "Requested pre-release identity ${PREID} does not match the pre-release identity ${EFFECTIVE_PREID:-<stable>} derived from ${MAIN_VERSION}." >&2
+            exit 1
           fi
 
           if [ -n "${EFFECTIVE_PREID}" ]; then
@@ -475,10 +481,7 @@ jobs:
             fi
           fi
 
-          COMMIT_SHA=$(git log -n 1 --format=%H -- "${PACKAGE_JSON}")
-          if [ -z "${COMMIT_SHA}" ]; then
-            COMMIT_SHA=$(git rev-parse HEAD)
-          fi
+          COMMIT_SHA=$(git rev-parse HEAD)
           {
             echo "name=${NAME}"
             echo "version=${TARGET_VER}"
@@ -486,4 +489,5 @@ jobs:
             echo "flags=${FLAGS}"
             echo "published=${PUBLISHED}"
             echo "commit_sha=${COMMIT_SHA}"
+            echo "effective_preid=${EFFECTIVE_PREID}"
           } >> "${GITHUB_OUTPUT}"

--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,3 @@
-//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
 @plasius:registry=https://registry.npmjs.org
 package-lock=true
 access=public

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,14 @@ The format is based on **[Keep a Changelog](https://keepachangelog.com/en/1.1.0/
   - (placeholder)
 
 - **Changed**
+  - Bound npm publication to the exact prepared `main` commit after successful push-triggered CI.
   - (placeholder)
 
 - **Fixed**
   - (placeholder)
 
 - **Security**
+  - Removed the npm write-token path, added a fail-closed npm 11.5.1-or-newer OIDC guard, and denied fork PR code access to self-hosted CI.
   - Added fail-closed source and npm-package admission for the administrative contributor registry and pinned the CI/CD runtime to Node.js 24.18.0 LTS.
   - (placeholder)
 

--- a/README.md
+++ b/README.md
@@ -472,7 +472,9 @@ GitHub Actions now carries the package delivery path:
 
 CI keeps the administrative contributor registry outside Git and npm package
 artifacts using exact, case-normalised path checks. CI runs on approved
-self-hosted runners. Release preparation and npm publication use GitHub-hosted
-runners with Node.js 24.18.0 LTS. CD remains disabled until the npm trusted
-publisher binding is verified and the legacy token fallback is removed.
+self-hosted runners for same-repository pull requests and `main`; fork PR code
+is denied. Publication uses the GitHub-hosted `production` job with Node 24 and
+npm 11.5.1 or newer. It is token-free and proceeds only while the prepared SHA
+is the exact `main` head after successful push-triggered CI. Do not dispatch CD
+until the npm trusted-publisher binding is verified.
 <!-- END PLASIUS RELEASE INTEGRITY -->

--- a/docs/adrs/adr-0007-hosted-oidc-package-publication.md
+++ b/docs/adrs/adr-0007-hosted-oidc-package-publication.md
@@ -10,6 +10,8 @@ accepting CI evidence for another source snapshot.
 
 ## Decision
 
+Publication is phase-isolated: dependency installation, package validation, SBOM generation, and immutable tarball packing run in `validate_and_pack` without the `production` environment or OIDC permission. The final hosted `publish` job downloads only that sealed artifact, explicitly installs npm 11.6.2, runs no repository dependency code, and publishes the tarball with lifecycle scripts disabled. It re-fetches current `main` immediately before the first release mutation and again immediately before npm publication. `.npmrc` contains no registry-auth placeholder, and release preparation returns the reviewed current `main` HEAD rather than package-file history.
+
 Publish only from the GitHub-hosted `production` job using npm trusted
 publishing. Prove the prepared SHA is still the exact remote `main` head and
 that push-triggered `ci.yml` succeeded for it. Require Node 24 and npm 11.5.1 or

--- a/docs/adrs/adr-0007-hosted-oidc-package-publication.md
+++ b/docs/adrs/adr-0007-hosted-oidc-package-publication.md
@@ -1,0 +1,26 @@
+# ADR-0007: Hosted OIDC Package Publication
+
+- Status: Accepted
+- Date: 2026-08-11
+
+## Context
+
+`@plasius/gpu-performance` must publish without a long-lived npm write token and without
+accepting CI evidence for another source snapshot.
+
+## Decision
+
+Publish only from the GitHub-hosted `production` job using npm trusted
+publishing. Prove the prepared SHA is still the exact remote `main` head and
+that push-triggered `ci.yml` succeeded for it. Require Node 24 and npm 11.5.1 or
+newer, request provenance, and prohibit npm write-token fallbacks. Same-repo PR
+CI may use explicit self-hosted runners; fork PR code is denied.
+
+## Consequences
+
+Missing trust configuration, moved `main`, absent CI, unsupported runtime, or
+missing OIDC identity fails closed before publication.
+
+## Test implications
+
+Workflow tests enforce source, CI, runtime, identity, runner, and token rules.

--- a/docs/adrs/index.md
+++ b/docs/adrs/index.md
@@ -6,3 +6,4 @@
 - [ADR-0004: Local Control Loop With Optional Telemetry Hooks](./adr-0004-local-control-loop-and-telemetry-hooks.md)
 - [ADR-0005: Worker-Job-First Governance](./adr-0005-worker-job-first-governance.md)
 - [ADR-0006: Multi-Dimensional LOD and Importance Governance](./adr-0006-multi-dimensional-lod-and-importance-governance.md)
+- [ADR-0007: Hosted OIDC Package Publication](./adr-0007-hosted-oidc-package-publication.md)

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const readWorkflow = (name: string): string =>
+  readFileSync(resolve(process.cwd(), `.github/workflows/${name}.yml`), "utf8");
+const cdWorkflow = readWorkflow("cd");
+const ciWorkflow = readWorkflow("ci");
+
+describe("package release trust boundary", () => {
+  it("uses exact-main hosted OIDC publication without write tokens", () => {
+    expect(cdWorkflow).toContain("runs-on: ubuntu-latest");
+    expect(cdWorkflow).toContain("environment: production");
+    expect(cdWorkflow).toContain("id-token: write");
+    expect(cdWorkflow).toContain("Enforce exact-main successful CI");
+    expect(cdWorkflow).toContain("refs/remotes/origin/main");
+    expect(cdWorkflow).toContain("-f branch=main");
+    expect(cdWorkflow).toContain("-f event=push");
+    expect(cdWorkflow).toContain('-f head_sha="${EXPECTED_SHA}"');
+    expect(cdWorkflow).toContain('conclusion == "success"');
+    expect(cdWorkflow).toContain("Verify release runtime");
+    expect(cdWorkflow).toContain('ACTUAL_NODE%%.*');
+    expect(cdWorkflow).toContain('"11.5.1"');
+    expect(cdWorkflow).toContain("--provenance");
+    expect(cdWorkflow).not.toMatch(/NPM_TOKEN|NODE_AUTH_TOKEN/u);
+  });
+
+  it("keeps same-repository pull-request CI on explicit trusted runners", () => {
+    expect(ciWorkflow).toContain("pull_request:");
+    expect(ciWorkflow).toContain("runs-on: [self-hosted, Linux, X64]");
+    expect(ciWorkflow).toContain("github.event.pull_request.head.repo.full_name == github.repository");
+    expect(ciWorkflow).not.toContain("pull_request_target");
+    expect(ciWorkflow).not.toContain("fromJSON(vars.");
+  });
+});


### PR DESCRIPTION
## Summary
- bind npm publication to exact successful push CI for the prepared `main` SHA
- require GitHub-hosted production OIDC publishing with Node 24/npm 11.5.1+
- deny fork PR code access to self-hosted CI and remove the npm write-token path
- document and test the release trust boundary

Closes #34

## Validation
- YAML and organisation semantic release audit: zero findings
- repository-required lint, typecheck, coverage, build, package verification, and runtime audit

This remains draft until the npm trusted-publisher binding is attested.